### PR TITLE
Implement global user data context

### DIFF
--- a/App.tsx
+++ b/App.tsx
@@ -22,12 +22,15 @@
 import { NavigationContainer } from '@react-navigation/native';
 import { StatusBar } from 'expo-status-bar';
 import Routes from './app/routes';
+import { UserProvider } from './context/UserDataContext';
 
 export default function App() {
   return (
     <NavigationContainer>
       <StatusBar style="light" />
-      <Routes />
+      <UserProvider>
+        <Routes />
+      </UserProvider>
     </NavigationContainer>
   );
 }

--- a/app/routes/types.ts
+++ b/app/routes/types.ts
@@ -7,10 +7,7 @@ export type RootStackParamList = {
   BattuInterpretation: { battuData: BattuData };
   TuviResult: { tuviData: TuviData };
   TuviInterpretation: { tuviData: TuviData };
-  Main: {
-    battuData: BattuData;
-    tuviData: TuviData;
-  }
+  Main: undefined;
   // thêm các màn khác nếu có
 };
 export type SplashScreenProps = {

--- a/app/screens/BattuInterpretationScreen.tsx
+++ b/app/screens/BattuInterpretationScreen.tsx
@@ -2,10 +2,12 @@ import React, { useEffect, useState } from 'react';
 import { View, Text, ActivityIndicator, StyleSheet } from 'react-native';
 import { RouteProp, useRoute } from '@react-navigation/native';
 import { RootStackParamList } from '../routes/types';
+import { useUserContext } from '../../context/UserDataContext';
 
 export default function BattuInterpretationScreen() {
   const route = useRoute<RouteProp<RootStackParamList, 'BattuInterpretation'>>();
   const { battuData } = route.params;
+  const { setBattuData } = useUserContext();
   const [result, setResult] = useState('');
 
   useEffect(() => {
@@ -14,6 +16,17 @@ export default function BattuInterpretationScreen() {
       setResult(`🌿 ${battuData.basic.name}, bạn mang mệnh “Giáp Tý” – người tiên phong, độc lập và giàu nội lực. Sự nghiệp sáng khi biết đi chậm mà chắc, tránh nóng vội...`);
     }, 2000);
   }, []);
+
+  useEffect(() => {
+    if (result) {
+      setBattuData({
+        basic: battuData.basic,
+        stems: battuData.stems,
+        branches: battuData.branches,
+        interpretation: result,
+      });
+    }
+  }, [result]);
 
   return (
     <View style={styles.container}>

--- a/app/screens/InputInfoScreen.tsx
+++ b/app/screens/InputInfoScreen.tsx
@@ -6,9 +6,11 @@ import { Picker } from '@react-native-picker/picker';
 import { useNavigation } from '@react-navigation/native';
 import { NativeStackNavigationProp } from '@react-navigation/native-stack';
 import { RootStackParamList } from '../routes/types';
+import { useUserContext } from '../../context/UserDataContext';
 
 export default function InputInfoScreen() {
   const navigation = useNavigation<NativeStackNavigationProp<RootStackParamList>>();
+  const { setUserData } = useUserContext();
   const [name, setName] = useState('');
   const [gender, setGender] = useState('Nam');
   const [birthDate, setBirthDate] = useState(new Date());
@@ -52,22 +54,9 @@ export default function InputInfoScreen() {
     navigation.navigate('TuviResult', { tuviData });
   };
 
-  const handleNext = () => {
-    const battuData = {
-      basic: { name, gender, birthDate, birthHour },
-      stems: ['Giáp', 'Tân', 'Canh', 'Mậu'],
-      branches: ['Tý', 'Dần', 'Ngọ', 'Hợi'],
-    };
-
-    const tuviData = {
-      basic: { name, gender, birthDate, birthHour },
-      cungMenh: 'Cấn',
-      menhChu: 'Thổ',
-      saoChieuMenh: ['Thái Âm', 'Thiên Cơ'],
-      tongQuan: 'Bạn là người kiên định, sống có nguyên tắc...',
-    };
-
-    navigation.navigate('Main', { battuData: battuData, tuviData: tuviData });
+  const handleStart = () => {
+    setUserData({ name, gender, birthDate, birthHour });
+    navigation.navigate('Main');
   };
 
   return (
@@ -124,7 +113,7 @@ export default function InputInfoScreen() {
 
       {/* <Button title="Xem Thiên Mệnh" onPress={xemBatTu} />
       <Button title="Xem Địa Duyên Mệnh" onPress={xemTuVi} /> */}
-      <Button title="Bắt đầu trải nghiệm" onPress={handleNext} />
+      <Button title="Bắt đầu trải nghiệm" onPress={handleStart} />
     </View>
   );
 }

--- a/app/screens/MainScreen.tsx
+++ b/app/screens/MainScreen.tsx
@@ -1,14 +1,13 @@
 import React, { useState } from 'react';
 import { View, Text, Button, StyleSheet, Alert } from 'react-native';
-import { RouteProp, useNavigation, useRoute } from '@react-navigation/native';
+import { useNavigation } from '@react-navigation/native';
 import { NativeStackNavigationProp } from '@react-navigation/native-stack';
 import { RootStackParamList } from '../routes/types';
+import { useUserContext } from '../../context/UserDataContext';
 
 export default function MainScreen() {
-  const route = useRoute<RouteProp<RootStackParamList, 'Main'>>();
   const navigation = useNavigation<NativeStackNavigationProp<RootStackParamList>>();
-
-  const { battuData, tuviData } = route.params;
+  const { battuData, tuviData } = useUserContext();
   const [hasBattuResult, setHasBattuResult] = useState(false);
   const [hasTuviResult, setHasTuviResult] = useState(false);
 

--- a/app/screens/TuviInterpretationScreen.tsx
+++ b/app/screens/TuviInterpretationScreen.tsx
@@ -2,10 +2,12 @@ import React, { useEffect, useState } from 'react';
 import { View, Text, ActivityIndicator, StyleSheet } from 'react-native';
 import { RouteProp, useRoute } from '@react-navigation/native';
 import { RootStackParamList } from '../routes/types';
+import { useUserContext } from '../../context/UserDataContext';
 
 export default function TuviInterpretationScreen() {
   const route = useRoute<RouteProp<RootStackParamList, 'TuviInterpretation'>>();
   const { tuviData } = route.params;
+  const { setTuviData } = useUserContext();
   const [result, setResult] = useState('');
 
   useEffect(() => {
@@ -14,6 +16,16 @@ export default function TuviInterpretationScreen() {
       setResult(`🌙 ${tuviData.basic.name}, bạn có cung mệnh Cấn và mệnh chủ Thổ. Lá số cho thấy sự ổn định, đáng tin cậy và nội lực mạnh mẽ. Những sao chiếu như ${tuviData.saoChieuMenh?.join(', ')} cho thấy bạn là người vừa có trí tuệ vừa có tình cảm...`);
     }, 2000);
   }, []);
+
+  useEffect(() => {
+    if (result) {
+      setTuviData({
+        basic: tuviData.basic,
+        tuviDetails: tuviData.tuviDetails ?? { saoChieuMenh: tuviData.saoChieuMenh || [] },
+        interpretation: result,
+      });
+    }
+  }, [result]);
 
   return (
     <View style={styles.container}>

--- a/context/UserDataContext.tsx
+++ b/context/UserDataContext.tsx
@@ -1,0 +1,55 @@
+import React, { createContext, useState, useContext } from 'react';
+
+type UserData = {
+  name: string;
+  gender: string;
+  birthDate: Date;
+  birthHour: string;
+};
+
+type BattuData = {
+  basic: UserData;
+  stems: string[];
+  branches: string[];
+  interpretation?: string;
+};
+
+type TuviData = {
+  basic: UserData;
+  tuviDetails: {
+    saoChieuMenh: string[];
+    [key: string]: any;
+  };
+  interpretation?: string;
+};
+
+type UserContextType = {
+  userData: UserData | null;
+  setUserData: (data: UserData) => void;
+  battuData: BattuData | null;
+  setBattuData: (data: BattuData) => void;
+  tuviData: TuviData | null;
+  setTuviData: (data: TuviData) => void;
+};
+
+const UserContext = createContext<UserContextType | undefined>(undefined);
+
+export const UserProvider = ({ children }: { children: React.ReactNode }) => {
+  const [userData, setUserData] = useState<UserData | null>(null);
+  const [battuData, setBattuData] = useState<BattuData | null>(null);
+  const [tuviData, setTuviData] = useState<TuviData | null>(null);
+
+  return (
+    <UserContext.Provider
+      value={{ userData, setUserData, battuData, setBattuData, tuviData, setTuviData }}
+    >
+      {children}
+    </UserContext.Provider>
+  );
+};
+
+export const useUserContext = () => {
+  const context = useContext(UserContext);
+  if (!context) throw new Error('useUserContext must be used within a UserProvider');
+  return context;
+};


### PR DESCRIPTION
## Summary
- add UserData context for sharing input data and results across screens
- wrap `App` with `UserProvider`
- save user info from InputInfoScreen and load data from context in MainScreen
- update interpretation screens to persist results in context
- adjust navigator types for Main screen

## Testing
- `npm test` *(fails: Missing script 'test')*

------
https://chatgpt.com/codex/tasks/task_e_6860df5061bc8333aa78ebec80934ee9