### PR TITLE
Refactor context to single user data

### DIFF
--- a/app/routes/types.ts
+++ b/app/routes/types.ts
@@ -3,10 +3,10 @@ export type RootStackParamList = {
   TramChanKhong: undefined;
   Onboarding: undefined;
   InputInfo: undefined;
-  BattuResult: { battuData: BattuData };
-  BattuInterpretation: { battuData: BattuData };
-  TuviResult: { tuviData: TuviData };
-  TuviInterpretation: { tuviData: TuviData };
+  BattuResult: undefined;
+  BattuInterpretation: undefined;
+  TuviResult: undefined;
+  TuviInterpretation: undefined;
   Main: undefined;
   // thêm các màn khác nếu có
 };
@@ -21,18 +21,16 @@ export type UserData = {
   gender: string;
   birthDate: Date;
   birthHour: string;
+  battu?: {
+    stems: string[];
+    branches: string[];
+    interpretation?: string;
+  };
+  tuvi?: {
+    tuviDetails: {
+      saoChieuMenh: string[];
+      [key: string]: any;
+    };
+    interpretation?: string;
+  };
 };
-
-export type BattuData = {
-  basic: UserData;
-  stems?: string[];
-  branches?: string[];
-};
-
-export type TuviData = {
-  basic: UserData;
-  cungMenh?: string,
-  menhChu?: string,
-  saoChieuMenh?: string[],
-  tongQuan?: string,
-}

--- a/app/screens/BattuInterpretationScreen.tsx
+++ b/app/screens/BattuInterpretationScreen.tsx
@@ -1,29 +1,24 @@
 import React, { useEffect, useState } from 'react';
 import { View, Text, ActivityIndicator, StyleSheet } from 'react-native';
-import { RouteProp, useRoute } from '@react-navigation/native';
-import { RootStackParamList } from '../routes/types';
 import { useUserContext } from '../../context/UserDataContext';
 
 export default function BattuInterpretationScreen() {
-  const route = useRoute<RouteProp<RootStackParamList, 'BattuInterpretation'>>();
-  const { battuData } = route.params;
-  const { setBattuData } = useUserContext();
+  const { userData, setUserData } = useUserContext();
   const [result, setResult] = useState('');
 
   useEffect(() => {
     // Mock fetch GPT luận giải
-    setTimeout(() => {
-      setResult(`🌿 ${battuData.basic.name}, bạn mang mệnh “Giáp Tý” – người tiên phong, độc lập và giàu nội lực. Sự nghiệp sáng khi biết đi chậm mà chắc, tránh nóng vội...`);
-    }, 2000);
+    if (userData) {
+      setTimeout(() => {
+        setResult(`🌿 ${userData.name}, bạn mang mệnh “Giáp Tý” – người tiên phong, độc lập và giàu nội lực. Sự nghiệp sáng khi biết đi chậm mà chắc, tránh nóng vội...`);
+      }, 2000);
+    }
   }, []);
 
   useEffect(() => {
-    if (result) {
-      setBattuData({
-        basic: battuData.basic,
-        stems: battuData.stems,
-        branches: battuData.branches,
-        interpretation: result,
+    if (result && userData?.battu) {
+      setUserData({
+        battu: { ...userData.battu, interpretation: result },
       });
     }
   }, [result]);

--- a/app/screens/BattuResultScreen.tsx
+++ b/app/screens/BattuResultScreen.tsx
@@ -1,26 +1,33 @@
-import React from 'react';
+import React, { useEffect } from 'react';
 import { View, Text, Button, StyleSheet } from 'react-native';
-import { RouteProp, useNavigation, useRoute } from '@react-navigation/native';
+import { useNavigation } from '@react-navigation/native';
 import { NativeStackNavigationProp } from '@react-navigation/native-stack';
 import { RootStackParamList } from '../routes/types';
-
-type BattuResultRouteProp = RouteProp<RootStackParamList, 'BattuResult'>;
+import { useUserContext } from '../../context/UserDataContext';
 
 export default function BattuResultScreen() {
-  const route = useRoute<BattuResultRouteProp>();
   const navigation = useNavigation<NativeStackNavigationProp<RootStackParamList>>();
-  const { battuData } = route.params;
+  const { userData, setUserData } = useUserContext();
+
+  useEffect(() => {
+    if (userData && !userData.battu) {
+      setUserData({ battu: { stems: ['Giáp', 'Tân', 'Canh', 'Mậu'], branches: ['Tý', 'Dần', 'Ngọ', 'Hợi'] } });
+    }
+  }, []);
+
+  if (!userData?.battu) return null;
+  const battuData = userData.battu;
 
   return (
     <View style={styles.container}>
-      <Text style={styles.title}>Thiên Mệnh của {battuData.basic.name}</Text>
-      <Text style={styles.title}>Ngày Sinh: {battuData.basic.birthDate.toString()}</Text>
-      <Text style={styles.title}>Giờ Sinh: {battuData.basic.birthHour}</Text>
+      <Text style={styles.title}>Thiên Mệnh của {userData?.name}</Text>
+      <Text style={styles.title}>Ngày Sinh: {userData?.birthDate.toString()}</Text>
+      <Text style={styles.title}>Giờ Sinh: {userData?.birthHour}</Text>
       <Text style={styles.label}>Tứ trụ:</Text>
       <Text style={styles.text}>Can: {battuData.stems?.join(' - ')}</Text>
       <Text style={styles.text}>Chi: {battuData.branches?.join(' - ')}</Text>
-      
-      <Button title="Luận giải AI" onPress={() => navigation.navigate('BattuInterpretation', { battuData })} />
+
+      <Button title="Luận giải AI" onPress={() => navigation.navigate('BattuInterpretation')} />
     </View>
   );
 }

--- a/app/screens/InputInfoScreen.tsx
+++ b/app/screens/InputInfoScreen.tsx
@@ -1,5 +1,5 @@
 import React, { useState } from 'react';
-import { Platform, TextInputProps } from 'react-native';
+import { Platform } from 'react-native';
 import { View, Text, TextInput, Button, StyleSheet } from 'react-native';
 import DateTimePicker from '@react-native-community/datetimepicker';
 import { Picker } from '@react-native-picker/picker';
@@ -32,27 +32,6 @@ export default function InputInfoScreen() {
     'Hợi (21:00 - 23:00)' 
   ];
 
-  const xemBatTu = () => {
-    // MOCK CALL: Sau sẽ gọi API thật
-    const battuData = {
-      basic: { name, gender, birthDate, birthHour },
-      stems: ['Giáp', 'Tân', 'Canh', 'Mậu'],
-      branches: ['Tý', 'Dần', 'Ngọ', 'Hợi'],
-    };
-    navigation.navigate('BattuResult', { battuData });
-  };
-
-  const xemTuVi = () => {
-    // MOCK CALL: Sau sẽ gọi API thật
-    const tuviData = {
-      basic: { name, gender, birthDate, birthHour },
-        cungMenh: 'Cấn',
-        menhChu: 'Thổ',
-        saoChieuMenh: ['Thái Âm', 'Thiên Cơ'],
-        tongQuan: 'Bạn là người kiên định, sống có nguyên tắc...',
-    };
-    navigation.navigate('TuviResult', { tuviData });
-  };
 
   const handleStart = () => {
     setUserData({ name, gender, birthDate, birthHour });

--- a/app/screens/MainScreen.tsx
+++ b/app/screens/MainScreen.tsx
@@ -1,4 +1,4 @@
-import React, { useState } from 'react';
+import React from 'react';
 import { View, Text, Button, StyleSheet, Alert } from 'react-native';
 import { useNavigation } from '@react-navigation/native';
 import { NativeStackNavigationProp } from '@react-navigation/native-stack';
@@ -7,12 +7,10 @@ import { useUserContext } from '../../context/UserDataContext';
 
 export default function MainScreen() {
   const navigation = useNavigation<NativeStackNavigationProp<RootStackParamList>>();
-  const { battuData, tuviData } = useUserContext();
-  const [hasBattuResult, setHasBattuResult] = useState(false);
-  const [hasTuviResult, setHasTuviResult] = useState(false);
+  const { userData, setUserData } = useUserContext();
 
   const handleTouchTramChanKhong = () => {
-    if (!hasBattuResult || !hasTuviResult) {
+    if (!userData?.battu || !userData?.tuvi) {
       Alert.alert('Thông báo', 'Bạn cần xem Thiên Mệnh và Địa Duyên trước khi gieo quẻ.');
     } else {
     //   navigation.navigate('DivinationScreen');
@@ -25,15 +23,15 @@ export default function MainScreen() {
       <Text style={styles.title}>Trạm Chân Không</Text>
 
       <View style={styles.buttonContainer}>
-        <Button title="Xem Thiên Mệnh (Bát Tự)" onPress={() => {
-          setHasBattuResult(true);
-          navigation.navigate('BattuResult', { battuData });
-        }} />
+        <Button
+          title="Xem Thiên Mệnh (Bát Tự)"
+          onPress={() => navigation.navigate('BattuResult')}
+        />
 
-        <Button title="Xem Địa Duyên (Tử Vi)" onPress={() => {
-          setHasTuviResult(true);
-          navigation.navigate('TuviResult', { tuviData });
-        }} />
+        <Button
+          title="Xem Địa Duyên (Tử Vi)"
+          onPress={() => navigation.navigate('TuviResult')}
+        />
       </View>
 
       <Button title="Gieo tại Trạm Chân Không" onPress={handleTouchTramChanKhong} />

--- a/app/screens/TuviInterpretationScreen.tsx
+++ b/app/screens/TuviInterpretationScreen.tsx
@@ -1,28 +1,24 @@
 import React, { useEffect, useState } from 'react';
 import { View, Text, ActivityIndicator, StyleSheet } from 'react-native';
-import { RouteProp, useRoute } from '@react-navigation/native';
-import { RootStackParamList } from '../routes/types';
 import { useUserContext } from '../../context/UserDataContext';
 
 export default function TuviInterpretationScreen() {
-  const route = useRoute<RouteProp<RootStackParamList, 'TuviInterpretation'>>();
-  const { tuviData } = route.params;
-  const { setTuviData } = useUserContext();
+  const { userData, setUserData } = useUserContext();
   const [result, setResult] = useState('');
 
   useEffect(() => {
     // MOCK GPT
-    setTimeout(() => {
-      setResult(`🌙 ${tuviData.basic.name}, bạn có cung mệnh Cấn và mệnh chủ Thổ. Lá số cho thấy sự ổn định, đáng tin cậy và nội lực mạnh mẽ. Những sao chiếu như ${tuviData.saoChieuMenh?.join(', ')} cho thấy bạn là người vừa có trí tuệ vừa có tình cảm...`);
-    }, 2000);
+    if (userData?.tuvi) {
+      setTimeout(() => {
+        setResult(`🌙 ${userData.name}, bạn có cung mệnh Cấn và mệnh chủ Thổ. Lá số cho thấy sự ổn định, đáng tin cậy và nội lực mạnh mẽ. Những sao chiếu như ${userData.tuvi?.tuviDetails.saoChieuMenh.join(', ')} cho thấy bạn là người vừa có trí tuệ vừa có tình cảm...`);
+      }, 2000);
+    }
   }, []);
 
   useEffect(() => {
-    if (result) {
-      setTuviData({
-        basic: tuviData.basic,
-        tuviDetails: tuviData.tuviDetails ?? { saoChieuMenh: tuviData.saoChieuMenh || [] },
-        interpretation: result,
+    if (result && userData?.tuvi) {
+      setUserData({
+        tuvi: { ...userData.tuvi, interpretation: result },
       });
     }
   }, [result]);

--- a/app/screens/TuviResultScreen.tsx
+++ b/app/screens/TuviResultScreen.tsx
@@ -1,28 +1,32 @@
-import React from 'react';
+import React, { useEffect } from 'react';
 import { View, Text, StyleSheet, ScrollView, Button } from 'react-native';
-import { RouteProp, useNavigation, useRoute } from '@react-navigation/native';
+import { useNavigation } from '@react-navigation/native';
 import { NativeStackNavigationProp } from '@react-navigation/native-stack';
 import { RootStackParamList } from '../routes/types';
-
-type TuviResultRouteProp = RouteProp<RootStackParamList, 'TuviResult'>;
+import { useUserContext } from '../../context/UserDataContext';
 
 export default function TuviResultScreen() {
-  const route = useRoute<TuviResultRouteProp>();
   const navigation = useNavigation<NativeStackNavigationProp<RootStackParamList>>();
+  const { userData, setUserData } = useUserContext();
 
-  const { tuviData } = route.params;
+  useEffect(() => {
+    if (userData && !userData.tuvi) {
+      setUserData({ tuvi: { tuviDetails: { saoChieuMenh: ['Thái Âm', 'Thiên Cơ'] } } });
+    }
+  }, []);
+
+  if (!userData?.tuvi) return null;
+  const tuviData = userData.tuvi;
 
   return (
     <View style={styles.container}>
       <Text style={styles.title}>Địa Duyên – Lá số Tử Vi</Text>
-      <Text style={styles.text}>Tên: {tuviData.basic.name}</Text>
-      <Text style={styles.text}>Ngày Giờ Sinh: {tuviData.basic.birthDate.toString()}</Text>
-      <Text style={styles.text}>Cung Mệnh: {tuviData.basic.birthHour}</Text>
-      <Text style={styles.text}>Mệnh Chủ: {tuviData.cungMenh}</Text>
-      <Text style={styles.text}>Sao chiếu mệnh: {tuviData.saoChieuMenh?.join(', ')}</Text>
+      <Text style={styles.text}>Tên: {userData?.name}</Text>
+      <Text style={styles.text}>Ngày Giờ Sinh: {userData?.birthDate.toString()}</Text>
+      <Text style={styles.text}>Giờ Sinh: {userData?.birthHour}</Text>
+      <Text style={styles.text}>Sao chiếu mệnh: {tuviData.tuviDetails.saoChieuMenh?.join(', ')}</Text>
 
-      <Button title="Luận giải AI" onPress={() => navigation.navigate('TuviInterpretation', { tuviData })}
-      />
+      <Button title="Luận giải AI" onPress={() => navigation.navigate('TuviInterpretation')} />
     </View>
   );
 }

--- a/context/UserDataContext.tsx
+++ b/context/UserDataContext.tsx
@@ -1,48 +1,40 @@
 import React, { createContext, useState, useContext } from 'react';
 
-type UserData = {
+export type UserData = {
   name: string;
   gender: string;
   birthDate: Date;
   birthHour: string;
-};
-
-type BattuData = {
-  basic: UserData;
-  stems: string[];
-  branches: string[];
-  interpretation?: string;
-};
-
-type TuviData = {
-  basic: UserData;
-  tuviDetails: {
-    saoChieuMenh: string[];
-    [key: string]: any;
+  battu?: {
+    stems: string[];
+    branches: string[];
+    interpretation?: string;
   };
-  interpretation?: string;
+  tuvi?: {
+    tuviDetails: {
+      saoChieuMenh: string[];
+      [key: string]: any;
+    };
+    interpretation?: string;
+  };
 };
 
 type UserContextType = {
   userData: UserData | null;
-  setUserData: (data: UserData) => void;
-  battuData: BattuData | null;
-  setBattuData: (data: BattuData) => void;
-  tuviData: TuviData | null;
-  setTuviData: (data: TuviData) => void;
+  setUserData: (data: Partial<UserData>) => void;
 };
 
 const UserContext = createContext<UserContextType | undefined>(undefined);
 
 export const UserProvider = ({ children }: { children: React.ReactNode }) => {
-  const [userData, setUserData] = useState<UserData | null>(null);
-  const [battuData, setBattuData] = useState<BattuData | null>(null);
-  const [tuviData, setTuviData] = useState<TuviData | null>(null);
+  const [userDataState, setUserDataState] = useState<UserData | null>(null);
+
+  const setUserData = (data: Partial<UserData>) => {
+    setUserDataState((prev) => ({ ...(prev ?? ({} as UserData)), ...data }));
+  };
 
   return (
-    <UserContext.Provider
-      value={{ userData, setUserData, battuData, setBattuData, tuviData, setTuviData }}
-    >
+    <UserContext.Provider value={{ userData: userDataState, setUserData }}>
       {children}
     </UserContext.Provider>
   );


### PR DESCRIPTION
## Summary
- simplify `UserDataContext` by merging user, battu and tuvi data
- update navigation types to remove params for result screens
- refactor screens to read/write data from the context

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_6860f6daac8c8333a4de31233f8d11bb