### PR TITLE
Add Battu data generation

### DIFF
--- a/app/routes/types.ts
+++ b/app/routes/types.ts
@@ -24,6 +24,7 @@ export type UserData = {
   battu?: {
     stems: string[];
     branches: string[];
+    data: import('../../shared/types/battuTypes').BattuData;
     interpretation?: string;
   };
   tuvi?: {

--- a/app/screens/BattuResultScreen.tsx
+++ b/app/screens/BattuResultScreen.tsx
@@ -4,6 +4,7 @@ import { useNavigation } from '@react-navigation/native';
 import { NativeStackNavigationProp } from '@react-navigation/native-stack';
 import { RootStackParamList } from '../routes/types';
 import { useUserContext } from '../../context/UserDataContext';
+import { generateBattuData } from '../../shared/utils/battu';
 
 export default function BattuResultScreen() {
   const navigation = useNavigation<NativeStackNavigationProp<RootStackParamList>>();
@@ -11,7 +12,8 @@ export default function BattuResultScreen() {
 
   useEffect(() => {
     if (userData && !userData.battu) {
-      setUserData({ battu: { stems: ['Giáp', 'Tân', 'Canh', 'Mậu'], branches: ['Tý', 'Dần', 'Ngọ', 'Hợi'] } });
+      const data = generateBattuData(userData.birthDate);
+      setUserData({ battu: { stems: ['Giáp', 'Tân', 'Canh', 'Mậu'], branches: ['Tý', 'Dần', 'Ngọ', 'Hợi'], data } });
     }
   }, []);
 

--- a/context/UserDataContext.tsx
+++ b/context/UserDataContext.tsx
@@ -1,4 +1,5 @@
 import React, { createContext, useState, useContext } from 'react';
+import type { BattuData } from '../shared/types/battuTypes';
 
 export type UserData = {
   name: string;
@@ -8,6 +9,7 @@ export type UserData = {
   battu?: {
     stems: string[];
     branches: string[];
+    data: BattuData;
     interpretation?: string;
   };
   tuvi?: {

--- a/package.json
+++ b/package.json
@@ -27,7 +27,8 @@
     "react-native-screens": "^4.11.1",
     "react-native-svg": "15.11.2",
     "react-native-swiper": "^1.6.0",
-    "react-native-web": "^0.20.0"
+    "react-native-web": "^0.20.0",
+    "lunar-typescript": "^1.0.0"
   },
   "devDependencies": {
     "@babel/core": "^7.25.2",

--- a/shared/types/battuTypes.ts
+++ b/shared/types/battuTypes.ts
@@ -1,0 +1,22 @@
+export interface Pillar {
+  can: string;
+  chi: string;
+  element?: string; // ngũ hành
+  nạpâm?: string;
+  tàngCan?: string[];
+  trườngSinh?: string;
+  thầnSát?: string[];
+}
+
+export interface BattuData {
+  date: Date;
+  solar: string;
+  lunar: string;
+  tiếtKhí?: string;
+  pillars: {
+    year: Pillar;
+    month: Pillar;
+    day: Pillar;
+    hour: Pillar;
+  };
+}

--- a/shared/utils/battu.ts
+++ b/shared/utils/battu.ts
@@ -1,0 +1,51 @@
+import { Solar } from 'lunar-typescript';
+import type { BattuData, Pillar } from '../types/battuTypes';
+
+export function generateBattuData(date: Date): BattuData {
+  const solar = Solar.fromDate(date);
+  const lunar = solar.getLunar();
+
+  const getPillar = (canChi: string, nạpâm: string, tàngCan: string[], trườngSinh: string): Pillar => {
+    const [can, chi] = canChi.split('');
+    return {
+      can,
+      chi,
+      nạpâm,
+      tàngCan,
+      trườngSinh,
+    };
+  };
+
+  return {
+    date,
+    solar: `${solar.getYear()}-${solar.getMonth()}-${solar.getDay()}`,
+    lunar: `${lunar.getYear()}-${lunar.getMonth()}-${lunar.getDay()}`,
+    tiếtKhí: lunar.getJieQi(),
+    pillars: {
+      year: getPillar(
+        lunar.getYearInGanZhi(),
+        lunar.getYearNaYin(),
+        lunar.getYearHid(),
+        lunar.getYearChangSheng()
+      ),
+      month: getPillar(
+        lunar.getMonthInGanZhiExact(),
+        lunar.getMonthNaYin(),
+        lunar.getMonthHideGanExact(),
+        lunar.getMonthChangSheng()
+      ),
+      day: getPillar(
+        lunar.getDayInGanZhi(),
+        lunar.getDayNaYin(),
+        lunar.getDayHideGan(),
+        lunar.getDayChangSheng()
+      ),
+      hour: getPillar(
+        lunar.getTimeInGanZhi(),
+        lunar.getTimeNaYin(),
+        lunar.getTimeHideGan(),
+        lunar.getTimeChangSheng()
+      ),
+    },
+  };
+}


### PR DESCRIPTION
## Summary
- define `Pillar` and `BattuData` types
- create `generateBattuData` helper using `lunar-typescript`
- include Battu data inside `UserData` types
- mock Battu data with `generateBattuData`
- add `lunar-typescript` dependency

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_686219dcd9508333a5b0c198e3566f9e