### PR TITLE
refactor: depend on navigation in splash screen effect

### DIFF
--- a/app/screens/SplashScreen.tsx
+++ b/app/screens/SplashScreen.tsx
@@ -13,7 +13,7 @@ export default function SplashScreen() {
     }, 2000);
 
     return () => clearTimeout(timer);
-  }, []);
+  }, [navigation]);
 
   return (
     <View style={styles.container}>


### PR DESCRIPTION
## Summary
- include navigation in SplashScreen's useEffect dependency array
- keep timeout cleanup on unmount

## Testing
- `yarn test` *(fails: Command "test" not found)*
- `npx tsc --noEmit`

------
https://chatgpt.com/codex/tasks/task_e_68bf7fa972188333b8dd6313441f043f