### PR TITLE
Stop BreathingDot animation on unmount

### DIFF
--- a/app/components/BreathingDot.tsx
+++ b/app/components/BreathingDot.tsx
@@ -11,7 +11,7 @@ export default function BreathingDot({ progress }: Props) {
 
   useEffect(() => {
     if (progress) return; // dùng progress từ parent, không tự animate
-    Animated.loop(
+    const animation = Animated.loop(
       Animated.sequence([
         Animated.timing(local, {
           toValue: 1,
@@ -26,8 +26,14 @@ export default function BreathingDot({ progress }: Props) {
           easing: Easing.inOut(Easing.quad),
         }),
       ])
-    ).start();
-  }, [progress]);
+    );
+
+    animation.start();
+
+    return () => {
+      animation.stop();
+    };
+  }, [progress, local]);
 
   const p = progress ?? local;
 


### PR DESCRIPTION
## Summary
- keep a reference to the BreathingDot animation loop and stop it on cleanup to avoid lingering animations

## Testing
- `npx tsc --noEmit`
- `node - <<'NODE'\nlet stopped = false;\nconst Animated = {\n  loop: () => ({ start: () => {}, stop: () => { stopped = true; } }),\n  sequence: (a) => a,\n  timing: () => ({})\n};\nconst Easing = { inOut: () => {}, quad: {} };\nconst animation = Animated.loop(\n  Animated.sequence([\n    Animated.timing({}, { toValue: 1, duration: 2000, useNativeDriver: true, easing: Easing.inOut(Easing.quad) }),\n    Animated.timing({}, { toValue: 0, duration: 2000, useNativeDriver: true, easing: Easing.inOut(Easing.quad) })\n  ])\n);\nanimation.start();\nanimation.stop();\nconsole.log('animation stopped:', stopped);\nNODE`
- `npm test` (fails: Missing script)
- `yarn test` (fails: Command "test" not found)


------
https://chatgpt.com/codex/tasks/task_e_68bf7fb33a6483339ae4659c0662753a