### PR TITLE
Stop breath animation on unmount

### DIFF
--- a/app/screens/TramChanKhongScreen.tsx
+++ b/app/screens/TramChanKhongScreen.tsx
@@ -15,7 +15,7 @@ export default function TramChanKhongScreen() {
   const breath = useRef(new Animated.Value(0)).current;
 
   useEffect(() => {
-    Animated.loop(
+    const animation = Animated.loop(
       Animated.sequence([
         Animated.timing(breath, {
           toValue: 1,
@@ -30,7 +30,11 @@ export default function TramChanKhongScreen() {
           easing: Easing.inOut(Easing.quad),
         }),
       ])
-    ).start();
+    );
+    animation.start();
+    return () => {
+      animation.stop();
+    };
   }, [breath]);
 
   // 2) Quotes hiển thị theo chu kỳ thở (đổi mỗi FULL_CYCLE_MS)

--- a/app/screens/__tests__/TramChanKhongScreen.test.tsx
+++ b/app/screens/__tests__/TramChanKhongScreen.test.tsx
@@ -1,0 +1,46 @@
+import React from 'react';
+import { act, create } from 'react-test-renderer';
+import TramChanKhongScreen from '../TramChanKhongScreen';
+
+// Mocks
+const mockStart = jest.fn();
+const mockStop = jest.fn();
+const mockLoop = jest.fn(() => ({ start: mockStart, stop: mockStop }));
+
+jest.mock('react-native', () => ({
+  View: 'View',
+  Text: 'Text',
+  StyleSheet: { create: () => ({}) },
+  Pressable: 'Pressable',
+  Animated: {
+    Value: jest.fn(() => ({ interpolate: jest.fn() })),
+    timing: jest.fn(),
+    sequence: jest.fn(),
+    loop: mockLoop,
+    Easing: { inOut: jest.fn(() => jest.fn()), quad: 'quad' },
+  },
+}));
+
+jest.mock('@react-navigation/native', () => ({
+  useNavigation: () => ({ navigate: jest.fn() }),
+}));
+
+jest.mock('../../components/BreathingDot', () => () => null);
+
+describe('TramChanKhongScreen', () => {
+  it('stops the looping animation on unmount', () => {
+    jest.useFakeTimers();
+    let renderer: any;
+    act(() => {
+      renderer = create(<TramChanKhongScreen />);
+    });
+    expect(mockStart).toHaveBeenCalled();
+
+    act(() => {
+      renderer.unmount();
+    });
+    expect(mockStop).toHaveBeenCalled();
+    jest.runOnlyPendingTimers();
+    jest.useRealTimers();
+  });
+});

--- a/jest.config.js
+++ b/jest.config.js
@@ -1,0 +1,4 @@
+module.exports = {
+  preset: 'ts-jest',
+  testEnvironment: 'jsdom',
+};

--- a/package.json
+++ b/package.json
@@ -7,7 +7,8 @@
     "start": "expo start",
     "android": "expo run:android",
     "ios": "expo run:ios",
-    "web": "expo start --web"
+    "web": "expo start --web",
+    "test": "jest"
   },
   "dependencies": {
     "@expo/metro-runtime": "~5.0.4",
@@ -29,7 +30,11 @@
   },
   "devDependencies": {
     "@babel/core": "^7.25.2",
+    "@types/jest": "^29.5.12",
     "@types/react": "~19.0.10",
+    "jest": "^29.7.0",
+    "react-test-renderer": "^19.0.0",
+    "ts-jest": "^29.1.1",
     "typescript": "~5.8.3"
   },
   "private": true,


### PR DESCRIPTION
## Summary
- ensure TramChanKhongScreen stops its looping breath animation when unmounting
- add Jest configuration and tests for TramChanKhongScreen

## Testing
- `yarn test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_68bf7fb6c85083339580eb635a3e73a5