### PR TITLE
chore: remove unused SplashScreenProps type

### DIFF
--- a/types.ts
+++ b/types.ts
@@ -4,8 +4,3 @@ export type RootStackParamList = {
   Onboarding: undefined;
   // thêm các màn khác nếu có
 };
-export type SplashScreenProps = {
-  navigation: {
-    navigate: (screen: keyof RootStackParamList) => void;
-  };
-};


### PR DESCRIPTION
## Summary
- remove obsolete `SplashScreenProps` type from `types.ts`
- ensure no files reference removed type

## Testing
- `yarn test` *(fails: Command "test" not found)*

------
https://chatgpt.com/codex/tasks/task_e_68bf7fbd36bc8333ab0aeb05044e4c64