### PR TITLE
Add ProfileSetup screen route and type

### DIFF
--- a/app/routes/index.tsx
+++ b/app/routes/index.tsx
@@ -5,6 +5,7 @@ import { RootStackParamList } from '../../types';
 import SplashScreen from '../screens/SplashScreen';
 import TramChanKhongScreen from '../screens/TramChanKhongScreen';
 import OnboardingScreen from '../screens/OnboardingScreen';
+import ProfileSetupScreen from '../screens/ProfileSetupScreen';
 
 
 const Stack = createNativeStackNavigator<RootStackParamList>();
@@ -23,6 +24,11 @@ export default function Routes() {
           contentStyle: { backgroundColor: 'transparent' },
           // iOS có blur/transparent tốt; Android cần overlay View trong component
         }}
+      />
+      <Stack.Screen
+        name="ProfileSetup"
+        component={ProfileSetupScreen}
+        options={{ animation: 'slide_from_left' }}
       />
     </Stack.Navigator>
   );

--- a/types.ts
+++ b/types.ts
@@ -2,5 +2,6 @@ export type RootStackParamList = {
   Splash: undefined;
   TramChanKhong: undefined;
   Onboarding: undefined;
+  ProfileSetup: undefined;
   // thêm các màn khác nếu có
 };


### PR DESCRIPTION
## Summary
- import ProfileSetupScreen and configure its stack screen with slide_from_left animation
- extend RootStackParamList with ProfileSetup

## Testing
- `npm test` *(fails: jest: not found)*
- `yarn install` *(fails: tunneling socket could not be established, 403)*

------
https://chatgpt.com/codex/tasks/task_e_68bf8c132b2c83339ae60c53a2113bb0