### PR TITLE
Add core navigation screens and layout components

### DIFF
--- a/app/components/BottomNav.tsx
+++ b/app/components/BottomNav.tsx
@@ -1,0 +1,42 @@
+import React from 'react';
+import { View, Text, StyleSheet, Pressable } from 'react-native';
+import { useNavigation } from '@react-navigation/native';
+import { NativeStackNavigationProp } from '@react-navigation/native-stack';
+import { RootStackParamList } from '../../types';
+
+export default function BottomNav() {
+  const navigation = useNavigation<NativeStackNavigationProp<RootStackParamList>>();
+  return (
+    <View style={styles.container}>
+      <Pressable onPress={() => navigation.navigate('Home')}>
+        <Text style={styles.text}>Home</Text>
+      </Pressable>
+      <Pressable onPress={() => navigation.navigate('ExploreSelf')}>
+        <Text style={styles.text}>Khám Phá Bản Thân</Text>
+      </Pressable>
+      <Pressable onPress={() => navigation.navigate('IChing')}>
+        <Text style={styles.text}>Soi Đường Quyết Định</Text>
+      </Pressable>
+      <Pressable onPress={() => navigation.navigate('ChuaLanh')}>
+        <Text style={styles.text}>Chữa Lành Cảm Xúc</Text>
+      </Pressable>
+      <Pressable onPress={() => navigation.navigate('KhaiMo')}>
+        <Text style={styles.text}>Khai Mở Vận Mệnh</Text>
+      </Pressable>
+    </View>
+  );
+}
+
+const styles = StyleSheet.create({
+  container: {
+    flexDirection: 'row',
+    justifyContent: 'space-around',
+    paddingVertical: 12,
+    borderTopWidth: StyleSheet.hairlineWidth,
+    borderTopColor: '#ccc',
+    backgroundColor: '#fff',
+  },
+  text: {
+    fontSize: 12,
+  },
+});

--- a/app/components/TopNav.tsx
+++ b/app/components/TopNav.tsx
@@ -1,0 +1,48 @@
+import React from 'react';
+import { View, Text, StyleSheet, Pressable } from 'react-native';
+import { useNavigation } from '@react-navigation/native';
+import { NativeStackNavigationProp } from '@react-navigation/native-stack';
+import { RootStackParamList } from '../../types';
+
+interface Props {
+  title: string;
+}
+
+export default function TopNav({ title }: Props) {
+  const navigation = useNavigation<NativeStackNavigationProp<RootStackParamList>>();
+  return (
+    <View style={styles.container}>
+      <Text style={styles.title}>{title}</Text>
+      <View style={styles.actions}>
+        <Text style={styles.icon}>🔍</Text>
+        <Text style={styles.icon}>🔔</Text>
+        <Pressable onPress={() => navigation.navigate('Profile')}>
+          <Text style={styles.icon}>👤</Text>
+        </Pressable>
+      </View>
+    </View>
+  );
+}
+
+const styles = StyleSheet.create({
+  container: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    justifyContent: 'space-between',
+    paddingHorizontal: 16,
+    paddingVertical: 12,
+    backgroundColor: '#fff',
+  },
+  title: {
+    fontSize: 18,
+    fontWeight: 'bold',
+  },
+  actions: {
+    flexDirection: 'row',
+    alignItems: 'center',
+  },
+  icon: {
+    fontSize: 18,
+    marginLeft: 12,
+  },
+});

--- a/app/routes/index.tsx
+++ b/app/routes/index.tsx
@@ -5,6 +5,15 @@ import { RootStackParamList } from '../../types';
 import SplashScreen from '../screens/SplashScreen';
 import TramChanKhongScreen from '../screens/TramChanKhongScreen';
 import OnboardingScreen from '../screens/OnboardingScreen';
+import ProfileSetupScreen from '../screens/ProfileSetupScreen';
+import LoadingProfileScreen from '../screens/LoadingProfileScreen';
+import RegistrationScreen from '../screens/RegistrationScreen';
+import HomeScreen from '../screens/HomeScreen';
+import ExploreSelfScreen from '../screens/ExploreSelfScreen';
+import IChingScreen from '../screens/IChingScreen';
+import ChuaLanhCamXucScreen from '../screens/ChuaLanhCamXucScreen';
+import KhaiMoVanMenhScreen from '../screens/KhaiMoVanMenhScreen';
+import ProfileScreen from '../screens/ProfileScreen';
 
 
 const Stack = createNativeStackNavigator<RootStackParamList>();
@@ -14,14 +23,22 @@ export default function Routes() {
     <Stack.Navigator screenOptions={{ headerShown: false }}>
       <Stack.Screen name="Splash" component={SplashScreen} />
       <Stack.Screen name="TramChanKhong" component={TramChanKhongScreen} />
+      <Stack.Screen name="Onboarding" component={OnboardingScreen} />
+      <Stack.Screen name="ProfileSetup" component={ProfileSetupScreen} />
+      <Stack.Screen name="LoadingProfile" component={LoadingProfileScreen} />
+      <Stack.Screen name="Registration" component={RegistrationScreen} />
+      <Stack.Screen name="Home" component={HomeScreen} />
+      <Stack.Screen name="ExploreSelf" component={ExploreSelfScreen} />
+      <Stack.Screen name="IChing" component={IChingScreen} />
+      <Stack.Screen name="ChuaLanh" component={ChuaLanhCamXucScreen} />
+      <Stack.Screen name="KhaiMo" component={KhaiMoVanMenhScreen} />
       <Stack.Screen
-        name="Onboarding"
-        component={OnboardingScreen}
+        name="Profile"
+        component={ProfileScreen}
         options={{
           presentation: 'transparentModal',
-          animation: 'slide_from_bottom',
+          animation: 'slide_from_right',
           contentStyle: { backgroundColor: 'transparent' },
-          // iOS có blur/transparent tốt; Android cần overlay View trong component
         }}
       />
     </Stack.Navigator>

--- a/app/screens/ChuaLanhCamXucScreen.tsx
+++ b/app/screens/ChuaLanhCamXucScreen.tsx
@@ -1,0 +1,21 @@
+import React from 'react';
+import { View, Text, StyleSheet } from 'react-native';
+import TopNav from '../components/TopNav';
+import BottomNav from '../components/BottomNav';
+
+export default function ChuaLanhCamXucScreen() {
+  return (
+    <View style={styles.container}>
+      <TopNav title="Chữa Lành Cảm Xúc" />
+      <View style={styles.content}>
+        <Text>Chữa Lành Cảm Xúc</Text>
+      </View>
+      <BottomNav />
+    </View>
+  );
+}
+
+const styles = StyleSheet.create({
+  container: { flex: 1, backgroundColor: '#fff' },
+  content: { flex: 1, alignItems: 'center', justifyContent: 'center' },
+});

--- a/app/screens/ExploreSelfScreen.tsx
+++ b/app/screens/ExploreSelfScreen.tsx
@@ -1,0 +1,41 @@
+import React from 'react';
+import { View, Text, StyleSheet, Pressable } from 'react-native';
+import TopNav from '../components/TopNav';
+import BottomNav from '../components/BottomNav';
+
+export default function ExploreSelfScreen() {
+  return (
+    <View style={styles.container}>
+      <TopNav title="Khám Phá Bản Thân" />
+      <View style={styles.content}>
+        <Pressable style={styles.button}>
+          <Text style={styles.buttonText}>Xem Lá Số Bát Tự</Text>
+        </Pressable>
+        <Pressable style={styles.button}>
+          <Text style={styles.buttonText}>Xem Lá Số Tử Vi</Text>
+        </Pressable>
+        <Pressable style={styles.button}>
+          <Text style={styles.buttonText}>Tổng Hợp</Text>
+        </Pressable>
+      </View>
+      <BottomNav />
+    </View>
+  );
+}
+
+const styles = StyleSheet.create({
+  container: { flex: 1, backgroundColor: '#fff' },
+  content: {
+    flex: 1,
+    alignItems: 'center',
+    justifyContent: 'center',
+  },
+  button: {
+    backgroundColor: '#000',
+    paddingHorizontal: 20,
+    paddingVertical: 12,
+    borderRadius: 8,
+    marginVertical: 8,
+  },
+  buttonText: { color: '#fff', fontWeight: 'bold' },
+});

--- a/app/screens/HomeScreen.tsx
+++ b/app/screens/HomeScreen.tsx
@@ -1,0 +1,21 @@
+import React from 'react';
+import { View, Text, StyleSheet } from 'react-native';
+import TopNav from '../components/TopNav';
+import BottomNav from '../components/BottomNav';
+
+export default function HomeScreen() {
+  return (
+    <View style={styles.container}>
+      <TopNav title="TUSO" />
+      <View style={styles.content}>
+        <Text>Home</Text>
+      </View>
+      <BottomNav />
+    </View>
+  );
+}
+
+const styles = StyleSheet.create({
+  container: { flex: 1, backgroundColor: '#fff' },
+  content: { flex: 1, alignItems: 'center', justifyContent: 'center' },
+});

--- a/app/screens/IChingScreen.tsx
+++ b/app/screens/IChingScreen.tsx
@@ -1,0 +1,21 @@
+import React from 'react';
+import { View, Text, StyleSheet } from 'react-native';
+import TopNav from '../components/TopNav';
+import BottomNav from '../components/BottomNav';
+
+export default function IChingScreen() {
+  return (
+    <View style={styles.container}>
+      <TopNav title="Soi Đường Quyết Định" />
+      <View style={styles.content}>
+        <Text>Soi Đường Quyết Định</Text>
+      </View>
+      <BottomNav />
+    </View>
+  );
+}
+
+const styles = StyleSheet.create({
+  container: { flex: 1, backgroundColor: '#fff' },
+  content: { flex: 1, alignItems: 'center', justifyContent: 'center' },
+});

--- a/app/screens/KhaiMoVanMenhScreen.tsx
+++ b/app/screens/KhaiMoVanMenhScreen.tsx
@@ -1,0 +1,21 @@
+import React from 'react';
+import { View, Text, StyleSheet } from 'react-native';
+import TopNav from '../components/TopNav';
+import BottomNav from '../components/BottomNav';
+
+export default function KhaiMoVanMenhScreen() {
+  return (
+    <View style={styles.container}>
+      <TopNav title="Khai Mở Vận Mệnh" />
+      <View style={styles.content}>
+        <Text>Khai Mở Vận Mệnh</Text>
+      </View>
+      <BottomNav />
+    </View>
+  );
+}
+
+const styles = StyleSheet.create({
+  container: { flex: 1, backgroundColor: '#fff' },
+  content: { flex: 1, alignItems: 'center', justifyContent: 'center' },
+});

--- a/app/screens/LoadingProfileScreen.tsx
+++ b/app/screens/LoadingProfileScreen.tsx
@@ -4,13 +4,16 @@ import { useNavigation } from '@react-navigation/native';
 import { NativeStackNavigationProp } from '@react-navigation/native-stack';
 import { RootStackParamList } from '../../types';
 
-export default function OnboardingScreen() {
+export default function LoadingProfileScreen() {
   const navigation = useNavigation<NativeStackNavigationProp<RootStackParamList>>();
   return (
     <View style={styles.container}>
-      <Text style={styles.title}>Chào Mừng đến với TUSO</Text>
-      <Pressable style={styles.button} onPress={() => navigation.navigate('ProfileSetup')}>
-        <Text style={styles.buttonText}>Bắt Đầu Trải Nghiệm</Text>
+      <Text style={styles.title}>Hồ Sơ của bạn đang được thiết lập</Text>
+      <Pressable style={styles.button} onPress={() => navigation.navigate('Registration')}>
+        <Text style={styles.buttonText}>Tạo Tài Khoản Để Lưu Hồ Sơ</Text>
+      </Pressable>
+      <Pressable style={styles.button} onPress={() => navigation.navigate('ExploreSelf')}>
+        <Text style={styles.buttonText}>Khám Phá Bản Thân as Guest</Text>
       </Pressable>
     </View>
   );
@@ -19,23 +22,26 @@ export default function OnboardingScreen() {
 const styles = StyleSheet.create({
   container: {
     flex: 1,
-    backgroundColor: '#000',
     justifyContent: 'center',
     alignItems: 'center',
+    backgroundColor: '#fff',
+    padding: 16,
   },
   title: {
-    fontSize: 24,
-    color: '#fff',
+    fontSize: 20,
+    textAlign: 'center',
     marginBottom: 24,
   },
   button: {
-    backgroundColor: '#fff',
+    backgroundColor: '#000',
     paddingHorizontal: 20,
     paddingVertical: 12,
     borderRadius: 8,
+    marginTop: 12,
   },
   buttonText: {
-    color: '#000',
+    color: '#fff',
     fontWeight: 'bold',
+    textAlign: 'center',
   },
 });

--- a/app/screens/ProfileScreen.tsx
+++ b/app/screens/ProfileScreen.tsx
@@ -1,0 +1,45 @@
+import React from 'react';
+import { View, Text, StyleSheet, Pressable } from 'react-native';
+import { useNavigation } from '@react-navigation/native';
+import { NativeStackNavigationProp } from '@react-navigation/native-stack';
+import { RootStackParamList } from '../../types';
+
+export default function ProfileScreen() {
+  const navigation = useNavigation<NativeStackNavigationProp<RootStackParamList>>();
+  return (
+    <View style={styles.overlay}>
+      <Pressable style={styles.backdrop} onPress={() => navigation.goBack()} />
+      <View style={styles.panel}>
+        <Text style={styles.title}>My Profile</Text>
+        <Pressable style={styles.close} onPress={() => navigation.goBack()}>
+          <Text>Close</Text>
+        </Pressable>
+      </View>
+    </View>
+  );
+}
+
+const styles = StyleSheet.create({
+  overlay: {
+    flex: 1,
+    flexDirection: 'row',
+    backgroundColor: 'rgba(0,0,0,0.5)',
+    justifyContent: 'flex-end',
+  },
+  backdrop: {
+    flex: 1,
+  },
+  panel: {
+    width: '50%',
+    backgroundColor: '#fff',
+    padding: 16,
+  },
+  title: {
+    fontSize: 20,
+    marginBottom: 12,
+  },
+  close: {
+    marginTop: 24,
+    alignSelf: 'flex-start',
+  },
+});

--- a/app/screens/ProfileSetupScreen.tsx
+++ b/app/screens/ProfileSetupScreen.tsx
@@ -4,13 +4,13 @@ import { useNavigation } from '@react-navigation/native';
 import { NativeStackNavigationProp } from '@react-navigation/native-stack';
 import { RootStackParamList } from '../../types';
 
-export default function OnboardingScreen() {
+export default function ProfileSetupScreen() {
   const navigation = useNavigation<NativeStackNavigationProp<RootStackParamList>>();
   return (
     <View style={styles.container}>
-      <Text style={styles.title}>Chào Mừng đến với TUSO</Text>
-      <Pressable style={styles.button} onPress={() => navigation.navigate('ProfileSetup')}>
-        <Text style={styles.buttonText}>Bắt Đầu Trải Nghiệm</Text>
+      <Text style={styles.title}>Thiết Lập Hồ Sơ</Text>
+      <Pressable style={styles.button} onPress={() => navigation.navigate('LoadingProfile')}>
+        <Text style={styles.buttonText}>Khám Phá Bản Thân</Text>
       </Pressable>
     </View>
   );
@@ -19,23 +19,22 @@ export default function OnboardingScreen() {
 const styles = StyleSheet.create({
   container: {
     flex: 1,
-    backgroundColor: '#000',
     justifyContent: 'center',
     alignItems: 'center',
+    backgroundColor: '#fff',
   },
   title: {
     fontSize: 24,
-    color: '#fff',
     marginBottom: 24,
   },
   button: {
-    backgroundColor: '#fff',
+    backgroundColor: '#000',
     paddingHorizontal: 20,
     paddingVertical: 12,
     borderRadius: 8,
   },
   buttonText: {
-    color: '#000',
+    color: '#fff',
     fontWeight: 'bold',
   },
 });

--- a/app/screens/RegistrationScreen.tsx
+++ b/app/screens/RegistrationScreen.tsx
@@ -4,13 +4,13 @@ import { useNavigation } from '@react-navigation/native';
 import { NativeStackNavigationProp } from '@react-navigation/native-stack';
 import { RootStackParamList } from '../../types';
 
-export default function OnboardingScreen() {
+export default function RegistrationScreen() {
   const navigation = useNavigation<NativeStackNavigationProp<RootStackParamList>>();
   return (
     <View style={styles.container}>
-      <Text style={styles.title}>Chào Mừng đến với TUSO</Text>
-      <Pressable style={styles.button} onPress={() => navigation.navigate('ProfileSetup')}>
-        <Text style={styles.buttonText}>Bắt Đầu Trải Nghiệm</Text>
+      <Text style={styles.title}>Login/Signup</Text>
+      <Pressable style={styles.button} onPress={() => navigation.navigate('Home')}>
+        <Text style={styles.buttonText}>Login</Text>
       </Pressable>
     </View>
   );
@@ -19,23 +19,22 @@ export default function OnboardingScreen() {
 const styles = StyleSheet.create({
   container: {
     flex: 1,
-    backgroundColor: '#000',
     justifyContent: 'center',
     alignItems: 'center',
+    backgroundColor: '#fff',
   },
   title: {
     fontSize: 24,
-    color: '#fff',
     marginBottom: 24,
   },
   button: {
-    backgroundColor: '#fff',
+    backgroundColor: '#000',
     paddingHorizontal: 20,
     paddingVertical: 12,
     borderRadius: 8,
   },
   buttonText: {
-    color: '#000',
+    color: '#fff',
     fontWeight: 'bold',
   },
 });

--- a/app/screens/TramChanKhongScreen.tsx
+++ b/app/screens/TramChanKhongScreen.tsx
@@ -65,14 +65,17 @@ export default function TramChanKhongScreen() {
   });
 
   return (
-    <Pressable style={styles.container} onPress={() => navigation.navigate('Onboarding')}>
+    <View style={styles.container}>
       <Animated.Text style={[styles.title, { opacity: fade }]}>{QUOTES[idx]}</Animated.Text>
 
       <View style={styles.dotContainer}>
         <BreathingDot progress={breath} />
       </View>
 
-    </Pressable>
+      <Pressable style={styles.openGate} onPress={() => navigation.navigate('Onboarding')}>
+        <Text style={styles.openGateText}>Chạm để mở cổng</Text>
+      </Pressable>
+    </View>
   );
 }
 
@@ -94,5 +97,13 @@ const styles = StyleSheet.create({
     alignItems: 'center',
     justifyContent: 'center',
     flex: 1,
+  },
+  openGate: {
+    paddingVertical: 16,
+  },
+  openGateText: {
+    color: '#fff',
+    textAlign: 'center',
+    fontSize: 16,
   },
 });

--- a/types.ts
+++ b/types.ts
@@ -2,5 +2,13 @@ export type RootStackParamList = {
   Splash: undefined;
   TramChanKhong: undefined;
   Onboarding: undefined;
-  // thêm các màn khác nếu có
+  ProfileSetup: undefined;
+  LoadingProfile: undefined;
+  Registration: undefined;
+  Home: undefined;
+  ExploreSelf: undefined;
+  IChing: undefined;
+  ChuaLanh: undefined;
+  KhaiMo: undefined;
+  Profile: undefined;
 };


### PR DESCRIPTION
## Summary
- Implement top and bottom navigation components
- Add onboarding, profile setup, loading, registration, and main app screens
- Wire up stack routes for full navigation flow

## Testing
- `npm test` *(fails: jest not found)*
- `npm install jest@29.7.0` *(fails: 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_68bfeef5ecac8333b84ea8c7b781fc39