### PR TITLE
Add exploration modals and icon bottom navigation

### DIFF
--- a/app/components/BottomNav.tsx
+++ b/app/components/BottomNav.tsx
@@ -1,27 +1,28 @@
 import React from 'react';
-import { View, Text, StyleSheet, Pressable } from 'react-native';
+import { View, StyleSheet, Pressable } from 'react-native';
 import { useNavigation } from '@react-navigation/native';
 import { NativeStackNavigationProp } from '@react-navigation/native-stack';
 import { RootStackParamList } from '../../types';
+import { Ionicons } from '@expo/vector-icons';
 
 export default function BottomNav() {
   const navigation = useNavigation<NativeStackNavigationProp<RootStackParamList>>();
   return (
     <View style={styles.container}>
       <Pressable onPress={() => navigation.navigate('Home')}>
-        <Text style={styles.text}>Home</Text>
+        <Ionicons name="home" size={24} />
       </Pressable>
       <Pressable onPress={() => navigation.navigate('ExploreSelf')}>
-        <Text style={styles.text}>Khám Phá Bản Thân</Text>
+        <Ionicons name="person" size={24} />
       </Pressable>
       <Pressable onPress={() => navigation.navigate('IChing')}>
-        <Text style={styles.text}>Soi Đường Quyết Định</Text>
+        <Ionicons name="book" size={24} />
       </Pressable>
       <Pressable onPress={() => navigation.navigate('ChuaLanh')}>
-        <Text style={styles.text}>Chữa Lành Cảm Xúc</Text>
+        <Ionicons name="heart" size={24} />
       </Pressable>
       <Pressable onPress={() => navigation.navigate('KhaiMo')}>
-        <Text style={styles.text}>Khai Mở Vận Mệnh</Text>
+        <Ionicons name="star" size={24} />
       </Pressable>
     </View>
   );
@@ -35,8 +36,10 @@ const styles = StyleSheet.create({
     borderTopWidth: StyleSheet.hairlineWidth,
     borderTopColor: '#ccc',
     backgroundColor: '#fff',
-  },
-  text: {
-    fontSize: 12,
+    position: 'absolute',
+    bottom: 0,
+    left: 0,
+    right: 0,
+    width: '100%',
   },
 });

--- a/app/routes/index.tsx
+++ b/app/routes/index.tsx
@@ -14,6 +14,10 @@ import IChingScreen from '../screens/IChingScreen';
 import ChuaLanhCamXucScreen from '../screens/ChuaLanhCamXucScreen';
 import KhaiMoVanMenhScreen from '../screens/KhaiMoVanMenhScreen';
 import ProfileScreen from '../screens/ProfileScreen';
+import LaSoBatTuScreen from '../screens/LaSoBatTuScreen';
+import LaSoTuViScreen from '../screens/LaSoTuViScreen';
+import TongHopScreen from '../screens/TongHopScreen';
+import GieoQueScreen from '../screens/GieoQueScreen';
 
 
 const Stack = createNativeStackNavigator<RootStackParamList>();
@@ -32,6 +36,42 @@ export default function Routes() {
       <Stack.Screen name="IChing" component={IChingScreen} />
       <Stack.Screen name="ChuaLanh" component={ChuaLanhCamXucScreen} />
       <Stack.Screen name="KhaiMo" component={KhaiMoVanMenhScreen} />
+      <Stack.Screen
+        name="LaSoBatTu"
+        component={LaSoBatTuScreen}
+        options={{
+          presentation: 'transparentModal',
+          animation: 'slide_from_bottom',
+          contentStyle: { backgroundColor: 'transparent' },
+        }}
+      />
+      <Stack.Screen
+        name="LaSoTuVi"
+        component={LaSoTuViScreen}
+        options={{
+          presentation: 'transparentModal',
+          animation: 'slide_from_bottom',
+          contentStyle: { backgroundColor: 'transparent' },
+        }}
+      />
+      <Stack.Screen
+        name="TongHop"
+        component={TongHopScreen}
+        options={{
+          presentation: 'transparentModal',
+          animation: 'slide_from_bottom',
+          contentStyle: { backgroundColor: 'transparent' },
+        }}
+      />
+      <Stack.Screen
+        name="GieoQue"
+        component={GieoQueScreen}
+        options={{
+          presentation: 'transparentModal',
+          animation: 'slide_from_top',
+          contentStyle: { backgroundColor: 'transparent' },
+        }}
+      />
       <Stack.Screen
         name="Profile"
         component={ProfileScreen}

--- a/app/screens/ExploreSelfScreen.tsx
+++ b/app/screens/ExploreSelfScreen.tsx
@@ -2,19 +2,32 @@ import React from 'react';
 import { View, Text, StyleSheet, Pressable } from 'react-native';
 import TopNav from '../components/TopNav';
 import BottomNav from '../components/BottomNav';
+import { useNavigation } from '@react-navigation/native';
+import { NativeStackNavigationProp } from '@react-navigation/native-stack';
+import { RootStackParamList } from '../../types';
 
 export default function ExploreSelfScreen() {
+  const navigation = useNavigation<NativeStackNavigationProp<RootStackParamList>>();
   return (
     <View style={styles.container}>
       <TopNav title="Khám Phá Bản Thân" />
       <View style={styles.content}>
-        <Pressable style={styles.button}>
+        <Pressable
+          style={styles.button}
+          onPress={() => navigation.navigate('LaSoBatTu')}
+        >
           <Text style={styles.buttonText}>Xem Lá Số Bát Tự</Text>
         </Pressable>
-        <Pressable style={styles.button}>
+        <Pressable
+          style={styles.button}
+          onPress={() => navigation.navigate('LaSoTuVi')}
+        >
           <Text style={styles.buttonText}>Xem Lá Số Tử Vi</Text>
         </Pressable>
-        <Pressable style={styles.button}>
+        <Pressable
+          style={styles.button}
+          onPress={() => navigation.navigate('TongHop')}
+        >
           <Text style={styles.buttonText}>Tổng Hợp</Text>
         </Pressable>
       </View>

--- a/app/screens/GieoQueScreen.tsx
+++ b/app/screens/GieoQueScreen.tsx
@@ -1,0 +1,50 @@
+import React from 'react';
+import { View, Text, StyleSheet, Pressable } from 'react-native';
+import { useNavigation } from '@react-navigation/native';
+import { NativeStackNavigationProp } from '@react-navigation/native-stack';
+import { RootStackParamList } from '../../types';
+
+export default function GieoQueScreen() {
+  const navigation = useNavigation<NativeStackNavigationProp<RootStackParamList>>();
+  return (
+    <View style={styles.overlay}>
+      <View style={styles.modal}>
+        <Text style={styles.title}>Gieo Quẻ</Text>
+        <Pressable style={styles.button} onPress={() => navigation.goBack()}>
+          <Text style={styles.buttonText}>Xem Luận Giải</Text>
+        </Pressable>
+      </View>
+    </View>
+  );
+}
+
+const styles = StyleSheet.create({
+  overlay: {
+    flex: 1,
+    backgroundColor: 'rgba(0,0,0,0.3)',
+    justifyContent: 'flex-start',
+  },
+  modal: {
+    height: '80%',
+    backgroundColor: '#fff',
+    borderBottomLeftRadius: 16,
+    borderBottomRightRadius: 16,
+    padding: 16,
+  },
+  title: {
+    fontSize: 18,
+    fontWeight: 'bold',
+    marginBottom: 16,
+  },
+  button: {
+    backgroundColor: '#000',
+    paddingVertical: 12,
+    paddingHorizontal: 20,
+    borderRadius: 8,
+    alignSelf: 'flex-start',
+  },
+  buttonText: {
+    color: '#fff',
+    fontWeight: 'bold',
+  },
+});

--- a/app/screens/IChingScreen.tsx
+++ b/app/screens/IChingScreen.tsx
@@ -1,14 +1,20 @@
 import React from 'react';
-import { View, Text, StyleSheet } from 'react-native';
+import { View, Text, StyleSheet, Pressable } from 'react-native';
 import TopNav from '../components/TopNav';
 import BottomNav from '../components/BottomNav';
+import { useNavigation } from '@react-navigation/native';
+import { NativeStackNavigationProp } from '@react-navigation/native-stack';
+import { RootStackParamList } from '../../types';
 
 export default function IChingScreen() {
+  const navigation = useNavigation<NativeStackNavigationProp<RootStackParamList>>();
   return (
     <View style={styles.container}>
       <TopNav title="Soi Đường Quyết Định" />
       <View style={styles.content}>
-        <Text>Soi Đường Quyết Định</Text>
+        <Pressable style={styles.button} onPress={() => navigation.navigate('GieoQue')}>
+          <Text style={styles.buttonText}>Gieo Quẻ</Text>
+        </Pressable>
       </View>
       <BottomNav />
     </View>
@@ -18,4 +24,11 @@ export default function IChingScreen() {
 const styles = StyleSheet.create({
   container: { flex: 1, backgroundColor: '#fff' },
   content: { flex: 1, alignItems: 'center', justifyContent: 'center' },
+  button: {
+    backgroundColor: '#000',
+    paddingHorizontal: 20,
+    paddingVertical: 12,
+    borderRadius: 8,
+  },
+  buttonText: { color: '#fff', fontWeight: 'bold' },
 });

--- a/app/screens/LaSoBatTuScreen.tsx
+++ b/app/screens/LaSoBatTuScreen.tsx
@@ -1,0 +1,55 @@
+import React from 'react';
+import { View, Text, StyleSheet, Pressable } from 'react-native';
+import { useNavigation } from '@react-navigation/native';
+import { NativeStackNavigationProp } from '@react-navigation/native-stack';
+import { RootStackParamList } from '../../types';
+
+export default function LaSoBatTuScreen() {
+  const navigation = useNavigation<NativeStackNavigationProp<RootStackParamList>>();
+  return (
+    <View style={styles.overlay}>
+      <View style={styles.modal}>
+        <View style={styles.header}>
+          <Text style={styles.title}>Lá Số Bát Tự</Text>
+          <Pressable onPress={() => navigation.goBack()}>
+            <Text style={styles.close}>Đóng</Text>
+          </Pressable>
+        </View>
+        <View style={styles.content}>
+          <Text>Nội dung Lá Số Bát Tự</Text>
+        </View>
+      </View>
+    </View>
+  );
+}
+
+const styles = StyleSheet.create({
+  overlay: {
+    flex: 1,
+    backgroundColor: 'rgba(0,0,0,0.3)',
+    justifyContent: 'flex-end',
+  },
+  modal: {
+    height: '80%',
+    backgroundColor: '#fff',
+    borderTopLeftRadius: 16,
+    borderTopRightRadius: 16,
+    padding: 16,
+  },
+  header: {
+    flexDirection: 'row',
+    justifyContent: 'space-between',
+    alignItems: 'center',
+    marginBottom: 16,
+  },
+  title: {
+    fontSize: 18,
+    fontWeight: 'bold',
+  },
+  close: {
+    color: '#007AFF',
+  },
+  content: {
+    flex: 1,
+  },
+});

--- a/app/screens/LaSoTuViScreen.tsx
+++ b/app/screens/LaSoTuViScreen.tsx
@@ -1,0 +1,55 @@
+import React from 'react';
+import { View, Text, StyleSheet, Pressable } from 'react-native';
+import { useNavigation } from '@react-navigation/native';
+import { NativeStackNavigationProp } from '@react-navigation/native-stack';
+import { RootStackParamList } from '../../types';
+
+export default function LaSoTuViScreen() {
+  const navigation = useNavigation<NativeStackNavigationProp<RootStackParamList>>();
+  return (
+    <View style={styles.overlay}>
+      <View style={styles.modal}>
+        <View style={styles.header}>
+          <Text style={styles.title}>Lá Số Tử Vi</Text>
+          <Pressable onPress={() => navigation.goBack()}>
+            <Text style={styles.close}>Đóng</Text>
+          </Pressable>
+        </View>
+        <View style={styles.content}>
+          <Text>Nội dung Lá Số Tử Vi</Text>
+        </View>
+      </View>
+    </View>
+  );
+}
+
+const styles = StyleSheet.create({
+  overlay: {
+    flex: 1,
+    backgroundColor: 'rgba(0,0,0,0.3)',
+    justifyContent: 'flex-end',
+  },
+  modal: {
+    height: '80%',
+    backgroundColor: '#fff',
+    borderTopLeftRadius: 16,
+    borderTopRightRadius: 16,
+    padding: 16,
+  },
+  header: {
+    flexDirection: 'row',
+    justifyContent: 'space-between',
+    alignItems: 'center',
+    marginBottom: 16,
+  },
+  title: {
+    fontSize: 18,
+    fontWeight: 'bold',
+  },
+  close: {
+    color: '#007AFF',
+  },
+  content: {
+    flex: 1,
+  },
+});

--- a/app/screens/TongHopScreen.tsx
+++ b/app/screens/TongHopScreen.tsx
@@ -1,0 +1,55 @@
+import React from 'react';
+import { View, Text, StyleSheet, Pressable } from 'react-native';
+import { useNavigation } from '@react-navigation/native';
+import { NativeStackNavigationProp } from '@react-navigation/native-stack';
+import { RootStackParamList } from '../../types';
+
+export default function TongHopScreen() {
+  const navigation = useNavigation<NativeStackNavigationProp<RootStackParamList>>();
+  return (
+    <View style={styles.overlay}>
+      <View style={styles.modal}>
+        <View style={styles.header}>
+          <Text style={styles.title}>Tổng Hợp Bản Mệnh</Text>
+          <Pressable onPress={() => navigation.goBack()}>
+            <Text style={styles.close}>Đóng</Text>
+          </Pressable>
+        </View>
+        <View style={styles.content}>
+          <Text>Nội dung Tổng Hợp Bản Mệnh</Text>
+        </View>
+      </View>
+    </View>
+  );
+}
+
+const styles = StyleSheet.create({
+  overlay: {
+    flex: 1,
+    backgroundColor: 'rgba(0,0,0,0.3)',
+    justifyContent: 'flex-end',
+  },
+  modal: {
+    height: '80%',
+    backgroundColor: '#fff',
+    borderTopLeftRadius: 16,
+    borderTopRightRadius: 16,
+    padding: 16,
+  },
+  header: {
+    flexDirection: 'row',
+    justifyContent: 'space-between',
+    alignItems: 'center',
+    marginBottom: 16,
+  },
+  title: {
+    fontSize: 18,
+    fontWeight: 'bold',
+  },
+  close: {
+    color: '#007AFF',
+  },
+  content: {
+    flex: 1,
+  },
+});

--- a/types.ts
+++ b/types.ts
@@ -10,5 +10,9 @@ export type RootStackParamList = {
   IChing: undefined;
   ChuaLanh: undefined;
   KhaiMo: undefined;
+  LaSoBatTu: undefined;
+  LaSoTuVi: undefined;
+  TongHop: undefined;
+  GieoQue: undefined;
   Profile: undefined;
 };


### PR DESCRIPTION
## Summary
- add modal screens for Lá Số Bát Tự, Lá Số Tử Vi, Tổng Hợp, and Gieo Quẻ
- wire navigation buttons from Khám Phá Bản Thân and iChing to new modal screens
- convert bottom navigation to icons and fix it at the bottom

## Testing
- `yarn test` *(fails: jest: not found)*

------
https://chatgpt.com/codex/tasks/task_e_68bff411cfbc8333b25d8e25f9313843