### PR TITLE
feat: persist onboarding and profile setup state

### DIFF
--- a/App.tsx
+++ b/App.tsx
@@ -2,9 +2,21 @@ import 'react-native-gesture-handler';
 import { NavigationContainer } from '@react-navigation/native';
 import { StatusBar } from 'expo-status-bar';
 import { GestureHandlerRootView } from 'react-native-gesture-handler';
+import { useEffect } from 'react';
 import Routes from './app/routes';
+import { loadOnboardingState, loadProfileState } from './app/lib/persistence';
+import { useAppStore } from './app/lib/store';
 
 export default function App() {
+  useEffect(() => {
+    (async () => {
+      const [hasOnboarded, hasProfileSetup] = await Promise.all([
+        loadOnboardingState(),
+        loadProfileState(),
+      ]);
+      useAppStore.setState({ hasOnboarded, hasProfileSetup });
+    })();
+  }, []);
   return (
     <GestureHandlerRootView style={{ flex: 1 }}>
       <NavigationContainer>

--- a/app/lib/persistence.ts
+++ b/app/lib/persistence.ts
@@ -32,6 +32,26 @@ export const kv = {
   },
 };
 
+// Onboarding & ProfileSetup persistence helpers
+const ONBOARDING_KEY = 'onboarding_state';
+const PROFILE_KEY = 'profile_state';
+
+export async function loadOnboardingState() {
+  return kv.get<boolean>(ONBOARDING_KEY, false);
+}
+
+export async function saveOnboardingState(value: boolean) {
+  await kv.set(ONBOARDING_KEY, value);
+}
+
+export async function loadProfileState() {
+  return kv.get<boolean>(PROFILE_KEY, false);
+}
+
+export async function saveProfileState(value: boolean) {
+  await kv.set(PROFILE_KEY, value);
+}
+
 // Debounce util cho các tác vụ lưu cục bộ
 export function debounce<T extends (...args: any[]) => void>(fn: T, ms = 250) {
   let t: any;

--- a/app/lib/store.ts
+++ b/app/lib/store.ts
@@ -2,6 +2,7 @@
 import { create } from 'zustand';
 import { persist, createJSONStorage, StateStorage } from 'zustand/middleware';
 import AsyncStorage from '@react-native-async-storage/async-storage';
+import { saveOnboardingState, saveProfileState } from './persistence';
 
 // ---------- Types
 type SessionState = {
@@ -17,14 +18,21 @@ type Store = {
   session: SessionState;
   ui: UIState;
 
+  hasOnboarded: boolean;
+  hasProfileSetup: boolean;
+
   setSession: (patch: Partial<SessionState>) => void;
   setUI: (patch: Partial<UIState>) => void;
+  completeOnboarding: () => void;
+  completeProfileSetup: () => void;
 };
 
 // ---------- Defaults
-const defaultState: Pick<Store, 'session' | 'ui'> = {
+const defaultState: Pick<Store, 'session' | 'ui' | 'hasOnboarded' | 'hasProfileSetup'> = {
   session: {},
   ui: { theme: 'dark', onboardingCompleted: false },
+  hasOnboarded: false,
+  hasProfileSetup: false,
 };
 
 // ---------- Storage (AsyncStorage) with namespacing
@@ -51,6 +59,14 @@ export const useAppStore = create<Store>()(
       ...defaultState,
       setSession: (patch) => set((s) => ({ session: { ...s.session, ...patch } })),
       setUI: (patch) => set((s) => ({ ui: { ...s.ui, ...patch } })),
+      completeOnboarding: () => {
+        set({ hasOnboarded: true });
+        saveOnboardingState(true);
+      },
+      completeProfileSetup: () => {
+        set({ hasProfileSetup: true });
+        saveProfileState(true);
+      },
     }),
     {
       name: STORE_NAME,

--- a/app/screens/OnboardingScreen.tsx
+++ b/app/screens/OnboardingScreen.tsx
@@ -3,13 +3,19 @@ import { View, Text, StyleSheet, Pressable } from 'react-native';
 import { useNavigation } from '@react-navigation/native';
 import { NativeStackNavigationProp } from '@react-navigation/native-stack';
 import { RootStackParamList } from '../../types';
+import { useAppStore } from '../lib/store';
 
 export default function OnboardingScreen() {
   const navigation = useNavigation<NativeStackNavigationProp<RootStackParamList>>();
+  const completeOnboarding = useAppStore((s) => s.completeOnboarding);
+  const handleNext = () => {
+    completeOnboarding();
+    navigation.navigate('ProfileSetup');
+  };
   return (
     <View style={styles.container}>
       <Text style={styles.title}>Chào Mừng đến với TUSO</Text>
-      <Pressable style={styles.button} onPress={() => navigation.navigate('ProfileSetup')}>
+      <Pressable style={styles.button} onPress={handleNext}>
         <Text style={styles.buttonText}>Bắt Đầu Trải Nghiệm</Text>
       </Pressable>
     </View>

--- a/app/screens/ProfileSetupScreen.tsx
+++ b/app/screens/ProfileSetupScreen.tsx
@@ -3,13 +3,19 @@ import { View, Text, StyleSheet, Pressable } from 'react-native';
 import { useNavigation } from '@react-navigation/native';
 import { NativeStackNavigationProp } from '@react-navigation/native-stack';
 import { RootStackParamList } from '../../types';
+import { useAppStore } from '../lib/store';
 
 export default function ProfileSetupScreen() {
   const navigation = useNavigation<NativeStackNavigationProp<RootStackParamList>>();
+  const completeProfileSetup = useAppStore((s) => s.completeProfileSetup);
+  const handleNext = () => {
+    completeProfileSetup();
+    navigation.navigate('Home');
+  };
   return (
     <View style={styles.container}>
       <Text style={styles.title}>Thiết Lập Hồ Sơ</Text>
-      <Pressable style={styles.button} onPress={() => navigation.navigate('LoadingProfile')}>
+      <Pressable style={styles.button} onPress={handleNext}>
         <Text style={styles.buttonText}>Khám Phá Bản Thân</Text>
       </Pressable>
     </View>

--- a/app/screens/TramChanKhongScreen.tsx
+++ b/app/screens/TramChanKhongScreen.tsx
@@ -4,6 +4,7 @@ import BreathingDot from '../components/BreathingDot';
 import { useNavigation } from '@react-navigation/native';
 import { RootStackParamList } from '../../types';
 import { NativeStackNavigationProp } from '@react-navigation/native-stack';
+import { $ } from '../lib/store';
 
 const BREATH_PHASE_MS = 5000; // 2s hít / 2s thở
 const FULL_CYCLE_MS = BREATH_PHASE_MS * 2;
@@ -64,6 +65,17 @@ export default function TramChanKhongScreen() {
     outputRange: [0.4, 1, 0.4],
   });
 
+  const hasOnboarded = $.use((s) => s.hasOnboarded);
+  const hasProfileSetup = $.use((s) => s.hasProfileSetup);
+  const handleOpenGate = () => {
+    if (hasOnboarded && hasProfileSetup) {
+      navigation.navigate('Home');
+    } else if (hasOnboarded) {
+      navigation.navigate('ProfileSetup');
+    } else {
+      navigation.navigate('Onboarding');
+    }
+  };
   return (
     <View style={styles.container}>
       <Animated.Text style={[styles.title, { opacity: fade }]}>{QUOTES[idx]}</Animated.Text>
@@ -72,7 +84,7 @@ export default function TramChanKhongScreen() {
         <BreathingDot progress={breath} />
       </View>
 
-      <Pressable style={styles.openGate} onPress={() => navigation.navigate('Onboarding')}>
+      <Pressable style={styles.openGate} onPress={handleOpenGate}>
         <Text style={styles.openGateText}>Chạm để mở cổng</Text>
       </Pressable>
     </View>


### PR DESCRIPTION
## Summary
- persist onboarding and profile completion flags in AsyncStorage
- load persisted flags on app startup and update navigation
- mark onboarding/profile setup complete from screens

## Testing
- `yarn test` *(fails: Test environment jest-environment-jsdom cannot be found)*
- `yarn add -D jest-environment-jsdom` *(fails: tunneling socket could not be established, statusCode=403)*

------
https://chatgpt.com/codex/tasks/task_e_68c1009874c48333862eeb3c5fcafbc5